### PR TITLE
Empty unset service environment files

### DIFF
--- a/molecule/services/playbook.yml
+++ b/molecule/services/playbook.yml
@@ -42,6 +42,16 @@
           backend: filesystem
           filesystem:
             dir: /tmp/blocks
+      compactor:
+        server:
+          http_listen_port: 9011
+          grpc_listen_port: 9097
+        storage:
+          engine: blocks
+        blocks_storage:
+          backend: filesystem
+          filesystem:
+            dir: /tmp/blocks
     cortex_env_variables:
       ingester:
         KAEGER_AGENT_HOST: localhost

--- a/molecule/services/tests/test_services.py
+++ b/molecule/services/tests/test_services.py
@@ -27,9 +27,13 @@ def test_directories(host, dirs):
 
 @pytest.mark.parametrize("files", [
     "/cortex/cortex-ingester.yml",
+    "/cortex/cortex-compactor.yml",
+    "/cortex/cortex-readpath.yml",
     "/etc/systemd/system/cortex@.service",
     "/usr/local/bin/cortex-linux-amd64",
     "/etc/default/cortex-ingester",
+    "/etc/default/cortex-readpath",
+    "/etc/default/cortex-compactor",
 ])
 def test_files(host, files):
     f = host.file(files)
@@ -42,13 +46,18 @@ def test_user(host):
     assert host.user("vortex").exists
 
 
-def test_service(host):
-    s = host.service("cortex@ingester")
-    # assert s.is_enabled
+@pytest.mark.parametrize("service", [
+    "ingester",
+    "readpath",
+    "compactor",
+])
+def test_service(host, service):
+    s = host.service("cortex@%s" % service)
+    assert s.is_enabled
     assert s.is_running
 
 
-@pytest.mark.parametrize("port", [9009, 9010, 9095, 9096])
+@pytest.mark.parametrize("port", [9009, 9010, 9095, 9096, 9011, 9097])
 def test_socket(host, port):
     s = host.socket("tcp://0.0.0.0:%d" % port)
     assert s.is_listening
@@ -66,15 +75,20 @@ def test_config_file_explicit_target(host):
     assert config["target"] == "querier,store-gateway"
 
 
-def test_string(host):
+def test_env_ingester(host):
     f = host.file("/etc/default/cortex-ingester")
     assert "KAEGER_AGENT_HOST=localhost\n" in f.content_string
     assert "KAEGER_SAMPLER_PARAM=0\n" in f.content_string
     assert "KAEGER_SAMPLER_TYPE=const\n" in f.content_string
 
 
-def test_string2(host):
+def test_env_readpath(host):
     f = host.file("/etc/default/cortex-readpath")
     assert "KAEGER_SAMPLER_TYPE=probabilistic\n" in f.content_string
     assert "KAEGER_SAMPLER_PARAM=0.1\n" in f.content_string
     assert "KAEGER_SAMPLER_TYPE=probabilistic\n" in f.content_string
+
+
+def test_env_compactor(host):
+    f = host.file("/etc/default/cortex-compactor")
+    assert "=" not in f.content_string

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,5 +47,5 @@
     dest: "{{ cortex_environment_location }}/cortex-{{ item.key }}"
     mode: 0644
   notify: reload cortex
-  loop: "{{ cortex_env_variables | dict2items }}"
+  loop: "{{ dict(cortex_services.keys() | zip_longest([], fillvalue={}) | list) | combine(cortex_env_variables) | dict2items }}"
   when: not cortex_all_in_one

--- a/templates/cortex.service.j2
+++ b/templates/cortex.service.j2
@@ -10,7 +10,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={{ cortex_system_user }}
 Group={{ cortex_system_group }}
-EnvironmentFile=-{{ cortex_environment_location }}/cortex
+EnvironmentFile={{ cortex_environment_location }}/cortex
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ _cortex_binary_install_dir }}/cortex-linux-amd64 -config.file={{ cortex_config_dir }}/cortex.yml
 WorkingDirectory={{ cortex_db_dir }}

--- a/templates/cortex@.service.j2
+++ b/templates/cortex@.service.j2
@@ -9,7 +9,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 User={{ cortex_system_user }}
-EnvironmentFile=-{{ cortex_environment_location }}/cortex-%i
+EnvironmentFile={{ cortex_environment_location }}/cortex-%i
 Group={{ cortex_system_group }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ _cortex_binary_install_dir }}/cortex-linux-amd64 -config.file={{ cortex_config_dir }}/cortex-%i.yml


### PR DESCRIPTION
This change makes sure that services who do not have env variables
explicitly set still get an environment file, this way if environment
variables are unset they are also unset on the server.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>